### PR TITLE
Fix typos and code improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.idea/
+.DS_STORE
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Here I am going to explain the entities containning on this API client. In this 
 
 ## Methods
 
-1. <b>GetAllAvaliableCurrenciesAsync</b>: Returns all the currently avaliable currencies on the API
+1. <b>GetAllAvailableCurrenciesAsync</b>: Returns all the currently avaliable currencies on the API
 
 ```csharp
 var currencies = await frankfurter
-    .GetAllAvaliableCurrenciesAsync()
+    .GetAllAvailableCurrenciesAsync()
     .ConfigureAwait(false);
 ```
 

--- a/samples/Frankfurter.API.Client.Console/Frankfurter.API.Client.Console.csproj
+++ b/samples/Frankfurter.API.Client.Console/Frankfurter.API.Client.Console.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Frankfurter.API.Client" Version="1.0.0" />
+    <ProjectReference Include="..\..\src\Frankfurter.API.Client\Frankfurter.API.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Frankfurter.API.Client.Console/Program.cs
+++ b/samples/Frankfurter.API.Client.Console/Program.cs
@@ -62,4 +62,4 @@ var exchanges = await frankfurter
         new DateTime(2021,1,1) // End Date
     ).ConfigureAwait(false);
 
-Console.WriteLine("Finish Execution!");
+Console.WriteLine(@"Finish Execution!");

--- a/samples/Frankfurter.API.Client.Console/Program.cs
+++ b/samples/Frankfurter.API.Client.Console/Program.cs
@@ -3,9 +3,9 @@ using Frankfurter.API.Client.Domain;
 
 var frankfurter = new FrankfurterClient();
 
-// Get All avaliable currencies
+// Get All available currencies
 var currencies = await frankfurter
-    .GetAllAvaliableCurrenciesAsync()
+    .GetAllAvailableCurrenciesAsync()
     .ConfigureAwait(false);
 
 // Convert a specified amount of one currency to another
@@ -17,7 +17,7 @@ var exchange = await frankfurter
         CurrencyCode.USD // Currency to Convert
     ).ConfigureAwait(false);
 
-// Get the equivalent of one currency in a date to anothers
+// Get the currency equivalency amount of one currency in a date
 
 exchange = await frankfurter
     .CurrencyConvertByDateAsync(
@@ -26,7 +26,7 @@ exchange = await frankfurter
         CurrencyCode.BRL // Reference Currency
     ).ConfigureAwait(false);
 
-// Get the equivalent of one currency in the last published date to anothers
+//  Get the currency equivalency amount of one currency in the last published date
 
 exchange = await frankfurter
     .CurrencyConvertByLastPublishedDateAsync(
@@ -34,7 +34,7 @@ exchange = await frankfurter
         CurrencyCode.BRL // Reference Currency
     ).ConfigureAwait(false);
 
-// Get the equivalent of one currency in the last published date to anothers
+//  Get the currency equivalency amount of one currency in the last published date
 // with specified currencies to convert
 
 var toCurrencies = new List<CurrencyCode>

--- a/samples/Frankfurter.API.Client.WebApi/Frankfurter.API.Client.WebApi.csproj
+++ b/samples/Frankfurter.API.Client.WebApi/Frankfurter.API.Client.WebApi.csproj
@@ -9,9 +9,11 @@
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'https' " />
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'http' " />
   <ItemGroup>
-    <PackageReference Include="Frankfurter.API.Client.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Frankfurter.API.Client.DependencyInjection\Frankfurter.API.Client.DependencyInjection.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Frankfurter.API.Client.WebApi/Program.cs
+++ b/samples/Frankfurter.API.Client.WebApi/Program.cs
@@ -20,9 +20,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapGet("/currencies", (IFrankfurterClient client) =>
-{
-    return client.GetAllAvaliableCurrenciesAsync();
-})
+app.MapGet("/currencies", (IFrankfurterClient client) 
+        => client.GetAllAvaliableCurrenciesAsync())
 .WithName("Currencies")
 .WithOpenApi();

--- a/src/Frankfurter.API.Client.DependencyInjection/Frankfurter.API.Client.DependencyInjection.csproj
+++ b/src/Frankfurter.API.Client.DependencyInjection/Frankfurter.API.Client.DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.5.0</Version>
     <Authors>Leonardo Tosin</Authors>
     <PackageProjectUrl>https://github.com/TheLe0/frankfurter-api-client</PackageProjectUrl>
     <PackageIconUrl>https://user-images.githubusercontent.com/40045069/235474192-f401db30-9f2f-4202-8370-4670ab6d6953.png</PackageIconUrl>
@@ -12,11 +12,11 @@
 	  <Description>A DI package for the Frankfurter.API.Client package</Description>
 	  <Copyright>Copyright © Leonardo Tosin</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-	  <AssemblyVersion>1.1.0</AssemblyVersion>
-	  <FileVersion>1.1.0</FileVersion>
+	  <AssemblyVersion>1.5.0</AssemblyVersion>
+	  <FileVersion>1.5.0</FileVersion>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Frankfurter.API.Client/Domain/CurrencyCode.cs
+++ b/src/Frankfurter.API.Client/Domain/CurrencyCode.cs
@@ -2,7 +2,7 @@
 {
     public enum CurrencyCode
     {
-        None,
+        NONE,
         AUD, // Australian Dollar
         BGN, // Bulgarian Lev
         BRL, // Brazilian Real

--- a/src/Frankfurter.API.Client/Extensions/CurrencyCodeParser.cs
+++ b/src/Frankfurter.API.Client/Extensions/CurrencyCodeParser.cs
@@ -70,7 +70,7 @@ namespace Frankfurter.API.Client.Extensions
             else if (currencyCodeStr == Currencies.UnitedStatesDollar)
                 return CurrencyCode.USD;
             else
-                return CurrencyCode.None;
+                return CurrencyCode.NONE;
         }
 
         internal static string ToString(this CurrencyCode currencyCode)

--- a/src/Frankfurter.API.Client/Extensions/CurrencyCodeParser.cs
+++ b/src/Frankfurter.API.Client/Extensions/CurrencyCodeParser.cs
@@ -7,70 +7,39 @@ namespace Frankfurter.API.Client.Extensions
     {
         internal static CurrencyCode ToCurrencyCode(this string currencyCodeStr)
         {
-            if (currencyCodeStr == Currencies.AustralianDollar)
-                return CurrencyCode.AUD;
-            else if (currencyCodeStr == Currencies.BrazilianReal)
-                return CurrencyCode.BRL;
-            else if (currencyCodeStr == Currencies.BritishPound)
-                return CurrencyCode.GBP;
-            else if (currencyCodeStr == Currencies.BulgarianLev)
-                return CurrencyCode.BGN;
-            else if (currencyCodeStr == Currencies.CanadianDollar)
-                return CurrencyCode.CAD;
-            else if (currencyCodeStr == Currencies.ChineseRenminbiYuan)
-                return CurrencyCode.CNY;
-            else if (currencyCodeStr == Currencies.CzechKoruna)
-                return CurrencyCode.CZK;
-            else if (currencyCodeStr == Currencies.DanishKrone)
-                return CurrencyCode.DKK;
-            else if (currencyCodeStr == Currencies.Euro)
-                return CurrencyCode.EUR;
-            else if (currencyCodeStr == Currencies.HongKongDollar)
-                return CurrencyCode.HKD;
-            else if (currencyCodeStr == Currencies.HungarianForint)
-                return CurrencyCode.HUF;
-            else if (currencyCodeStr == Currencies.IcelandicKrona)
-                return CurrencyCode.ISK;
-            else if (currencyCodeStr == Currencies.IndianRupee)
-                return CurrencyCode.INR;
-            else if (currencyCodeStr == Currencies.IndonesianRupiah)
-                return CurrencyCode.IDR;
-            else if (currencyCodeStr == Currencies.IsraeliNewSheqel)
-                return CurrencyCode.ILS;
-            else if (currencyCodeStr == Currencies.JapaneseYen)
-                return CurrencyCode.JPY;
-            else if (currencyCodeStr == Currencies.MalaysianRinggit)
-                return CurrencyCode.MYR;
-            else if (currencyCodeStr == Currencies.MexicanPeso)
-                return CurrencyCode.MXN;
-            else if (currencyCodeStr == Currencies.NewZealandDollar)
-                return CurrencyCode.NZD;
-            else if (currencyCodeStr == Currencies.NorwegianKrone)
-                return CurrencyCode.NOK;
-            else if (currencyCodeStr == Currencies.PhilippinePeso)
-                return CurrencyCode.PHP;
-            else if (currencyCodeStr == Currencies.PolishZloty)
-                return CurrencyCode.PLN;
-            else if (currencyCodeStr == Currencies.RomanianLeu)
-                return CurrencyCode.RON;
-            else if (currencyCodeStr == Currencies.SingaporeDollar)
-                return CurrencyCode.SGD;
-            else if (currencyCodeStr == Currencies.SouthAfricanRand)
-                return CurrencyCode.ZAR;
-            else if (currencyCodeStr == Currencies.SouthKoreanWon)
-                return CurrencyCode.KRW;
-            else if (currencyCodeStr == Currencies.SwedishKrona)
-                return CurrencyCode.SEK;
-            else if (currencyCodeStr == Currencies.SwissFranc)
-                return CurrencyCode.CHF;
-            else if (currencyCodeStr == Currencies.ThaiBaht)
-                return CurrencyCode.THB;
-            else if (currencyCodeStr == Currencies.TurkishLira)
-                return CurrencyCode.TRY;
-            else if (currencyCodeStr == Currencies.UnitedStatesDollar)
-                return CurrencyCode.USD;
-            else
-                return CurrencyCode.NONE;
+            if (currencyCodeStr == Currencies.AustralianDollar) return CurrencyCode.AUD;
+            if (currencyCodeStr == Currencies.BrazilianReal) return CurrencyCode.BRL;
+            if (currencyCodeStr == Currencies.BritishPound) return CurrencyCode.GBP;
+            if (currencyCodeStr == Currencies.BulgarianLev) return CurrencyCode.BGN;
+            if (currencyCodeStr == Currencies.CanadianDollar) return CurrencyCode.CAD;
+            if (currencyCodeStr == Currencies.ChineseRenminbiYuan) return CurrencyCode.CNY;
+            if (currencyCodeStr == Currencies.CzechKoruna) return CurrencyCode.CZK;
+            if (currencyCodeStr == Currencies.DanishKrone) return CurrencyCode.DKK;
+            if (currencyCodeStr == Currencies.Euro) return CurrencyCode.EUR;
+            if (currencyCodeStr == Currencies.HongKongDollar) return CurrencyCode.HKD;
+            if (currencyCodeStr == Currencies.HungarianForint) return CurrencyCode.HUF;
+            if (currencyCodeStr == Currencies.IcelandicKrona) return CurrencyCode.ISK;
+            if (currencyCodeStr == Currencies.IndianRupee) return CurrencyCode.INR;
+            if (currencyCodeStr == Currencies.IndonesianRupiah) return CurrencyCode.IDR;
+            if (currencyCodeStr == Currencies.IsraeliNewSheqel) return CurrencyCode.ILS;
+            if (currencyCodeStr == Currencies.JapaneseYen) return CurrencyCode.JPY;
+            if (currencyCodeStr == Currencies.MalaysianRinggit) return CurrencyCode.MYR;
+            if (currencyCodeStr == Currencies.MexicanPeso) return CurrencyCode.MXN;
+            if (currencyCodeStr == Currencies.NewZealandDollar) return CurrencyCode.NZD;
+            if (currencyCodeStr == Currencies.NorwegianKrone) return CurrencyCode.NOK;
+            if (currencyCodeStr == Currencies.PhilippinePeso) return CurrencyCode.PHP;
+            if (currencyCodeStr == Currencies.PolishZloty) return CurrencyCode.PLN;
+            if (currencyCodeStr == Currencies.RomanianLeu) return CurrencyCode.RON;
+            if (currencyCodeStr == Currencies.SingaporeDollar) return CurrencyCode.SGD;
+            if (currencyCodeStr == Currencies.SouthAfricanRand) return CurrencyCode.ZAR;
+            if (currencyCodeStr == Currencies.SouthKoreanWon) return CurrencyCode.KRW;
+            if (currencyCodeStr == Currencies.SwedishKrona) return CurrencyCode.SEK;
+            if (currencyCodeStr == Currencies.SwissFranc) return CurrencyCode.CHF;
+            if (currencyCodeStr == Currencies.ThaiBaht) return CurrencyCode.THB;
+            if (currencyCodeStr == Currencies.TurkishLira) return CurrencyCode.TRY;
+            if (currencyCodeStr == Currencies.UnitedStatesDollar) return CurrencyCode.USD;
+
+            return CurrencyCode.NONE;
         }
 
         internal static string ToString(this CurrencyCode currencyCode)

--- a/src/Frankfurter.API.Client/Extensions/CurrencyParser.cs
+++ b/src/Frankfurter.API.Client/Extensions/CurrencyParser.cs
@@ -9,42 +9,26 @@ namespace Frankfurter.API.Client.Extensions
     {
         internal static IEnumerable<Currency> ToCurrencyList(this JsonObject jsonObject)
         {
-            var currencies = new List<Currency>();
-
             var listJsonObjs = jsonObject.ToArray();
 
-            for ( var i = 0; i < listJsonObjs.Length; i++)
-            {
-                currencies.Add(
-                    new Currency
-                    {
-                        Name = listJsonObjs[i].Value.ToString(),
-                        Code = listJsonObjs[i].Key.ToString().ToCurrencyCode()
-                    }
-                ); 
-            }
-
-            return currencies;
+            return listJsonObjs.Select(node 
+                => new Currency
+                {
+                    Name = node.Value.ToString(), 
+                    Code = node.Key.ToString().ToCurrencyCode()
+                }).ToList();
         }
 
         internal static IEnumerable<CurrencyRate> ToCurrencyRateList(this JsonObject jsonObject)
         {
-            var currencies = new List<CurrencyRate>();
-
             var listJsonObjs = jsonObject.ToArray();
 
-            for (var i = 0; i < listJsonObjs.Length; i++)
-            {
-                currencies.Add(
-                    new CurrencyRate
-                    {
-                        Amount = (decimal) listJsonObjs[i].Value,
-                        CurrencyCode = listJsonObjs[i].Key.ToCurrencyCode()
-                    }
-                );
-            }
-
-            return currencies;
+            return listJsonObjs.Select(node 
+                => new CurrencyRate
+                {
+                    Amount = (decimal) node.Value, 
+                    CurrencyCode = node.Key.ToCurrencyCode()
+                }).ToList();
         }
     }
 }

--- a/src/Frankfurter.API.Client/Extensions/EndpointParameterBuilder.cs
+++ b/src/Frankfurter.API.Client/Extensions/EndpointParameterBuilder.cs
@@ -15,7 +15,7 @@ namespace Frankfurter.API.Client.Extensions
 
             foreach (var currency in currencies)
             {
-                if (currency != CurrencyCode.None)
+                if (currency != CurrencyCode.NONE)
                 {
                     if (isFirstRow)
                     {

--- a/src/Frankfurter.API.Client/Extensions/EndpointParameterBuilder.cs
+++ b/src/Frankfurter.API.Client/Extensions/EndpointParameterBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using Frankfurter.API.Client.Domain;
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Text;
 
 namespace Frankfurter.API.Client.Extensions
@@ -11,23 +10,13 @@ namespace Frankfurter.API.Client.Extensions
         internal static string ToParameter(this IEnumerable<CurrencyCode> currencies)
         {
             var currenciesStr = new StringBuilder();
-            var isFirstRow = true;
 
             foreach (var currency in currencies)
             {
-                if (currency != CurrencyCode.NONE)
-                {
-                    if (isFirstRow)
-                    {
-                        currenciesStr.Append(',');
-                    }
-                    else
-                    {
-                        isFirstRow = false;
-                    }
-
-                    currenciesStr.Append(currency.ToString());
-                }
+                if (currency == CurrencyCode.NONE) continue;
+                
+                currenciesStr.Append(',');
+                currenciesStr.Append(currency.ToString());
             }
 
             return currenciesStr.ToString();

--- a/src/Frankfurter.API.Client/Extensions/ExchangeBaseApiResponseParser.cs
+++ b/src/Frankfurter.API.Client/Extensions/ExchangeBaseApiResponseParser.cs
@@ -21,23 +21,16 @@ namespace Frankfurter.API.Client.Extensions
 
         internal static IEnumerable<Exchange> ToExchangeList(this ExchangeBaseApiResponse apiResponse)
         {
-            var exchangeList = new List<Exchange>();
             var listJsonObjs = apiResponse.Rates.ToArray();
 
-            for (var i = 0; i < listJsonObjs.Length; i++)
-            {
-                exchangeList.Add(
-                    new Exchange
-                    {
-                        ReferenceDate = DateTime.Parse(listJsonObjs[i].Key),
-                        ReferenceAmount = apiResponse.Amount,
-                        ReferenceCurrency = apiResponse.Currency.ToCurrencyCode(),
-                        Rates = listJsonObjs[i].Value.AsObject().ToCurrencyRateList()
-                    }
-                );
-            }
-
-            return exchangeList;
+            return listJsonObjs.Select(node 
+                => new Exchange
+                {
+                    ReferenceDate = DateTime.Parse(node.Key), 
+                    ReferenceAmount = apiResponse.Amount, 
+                    ReferenceCurrency = apiResponse.Currency.ToCurrencyCode(), 
+                    Rates = node.Value.AsObject().ToCurrencyRateList()
+                }).ToList();
         }
     }
 }

--- a/src/Frankfurter.API.Client/Extensions/ExchangeBaseApiResponseValidator.cs
+++ b/src/Frankfurter.API.Client/Extensions/ExchangeBaseApiResponseValidator.cs
@@ -1,5 +1,4 @@
 ﻿using Frankfurter.API.Client.DTO.Response;
-using System;
 
 namespace Frankfurter.API.Client.Extensions
 {
@@ -7,12 +6,9 @@ namespace Frankfurter.API.Client.Extensions
     {
         internal static bool IsNull(this ExchangeBaseApiResponse exchangeBaseApiResponse)
         {
-            if (exchangeBaseApiResponse == null) return true;
-            if (exchangeBaseApiResponse.Rates == null) return true;
+            if (exchangeBaseApiResponse?.Rates == null) return true;
             if (exchangeBaseApiResponse.Amount == decimal.Zero) return true;
-            if (exchangeBaseApiResponse.Currency == null) return true;
-
-            return false;
+            return exchangeBaseApiResponse.Currency == null;
         }
     }
 }

--- a/src/Frankfurter.API.Client/Frankfurter.API.Client.csproj
+++ b/src/Frankfurter.API.Client/Frankfurter.API.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.1.0</Version>
+    <Version>1.5.0</Version>
     <Authors>Leonardo Tosin</Authors>
     <PackageProjectUrl>https://github.com/TheLe0/frankfurter-api-client</PackageProjectUrl>
     <PackageIconUrl>https://user-images.githubusercontent.com/40045069/235474192-f401db30-9f2f-4202-8370-4670ab6d6953.png</PackageIconUrl>
@@ -12,11 +12,11 @@
 	  <Description>A .NET client library for a currency exchange REST API called Frankfurter</Description>
 	  <Copyright>Copyright © Leonardo Tosin</Copyright>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-	  <AssemblyVersion>1.1.0</AssemblyVersion>
-	  <FileVersion>1.1.0</FileVersion>
+	  <AssemblyVersion>1.5.0</AssemblyVersion>
+	  <FileVersion>1.5.0</FileVersion>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Frankfurter.API.Client/FrankfurterBaseApiClient.cs
+++ b/src/Frankfurter.API.Client/FrankfurterBaseApiClient.cs
@@ -1,9 +1,8 @@
 ﻿using Flurl;
 using Frankfurter.API.Client.Configuration;
-using Frankfurter.API.Client.Infraestructure;
 using RestSharp;
-using System.Net.Http;
 using System.Threading.Tasks;
+using Frankfurter.API.Client.Infrastructure;
 
 namespace Frankfurter.API.Client
 {

--- a/src/Frankfurter.API.Client/FrankfurterClient.cs
+++ b/src/Frankfurter.API.Client/FrankfurterClient.cs
@@ -35,8 +35,8 @@ namespace Frankfurter.API.Client
             Endpoint.AppendPathSegment(Routes.LatestEndpoint);
 
             if (amount > decimal.Zero) Endpoint.SetQueryParam("amount", amount);
-            if (from != CurrencyCode.None) Endpoint.SetQueryParam("from", from.ToString());
-            if (to != CurrencyCode.None) Endpoint.SetQueryParam("to", to.ToString());
+            if (from != CurrencyCode.NONE) Endpoint.SetQueryParam("from", from.ToString());
+            if (to != CurrencyCode.NONE) Endpoint.SetQueryParam("to", to.ToString());
 
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
@@ -52,7 +52,7 @@ namespace Frankfurter.API.Client
             Endpoint.AppendPathSegment(referenceDate.ToString("yyyy-MM-dd"));
 
             if (amount > decimal.Zero) Endpoint.SetQueryParam("amount", amount);
-            if (from != CurrencyCode.None) Endpoint.SetQueryParam("from", from.ToString());
+            if (from != CurrencyCode.NONE) Endpoint.SetQueryParam("from", from.ToString());
 
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
@@ -67,7 +67,7 @@ namespace Frankfurter.API.Client
             Endpoint.AppendPathSegment(Routes.LatestEndpoint);
 
             if (amount > decimal.Zero) Endpoint.SetQueryParam("amount", amount);
-            if (from != CurrencyCode.None) Endpoint.SetQueryParam("from", from.ToString());
+            if (from != CurrencyCode.NONE) Endpoint.SetQueryParam("from", from.ToString());
 
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
@@ -82,7 +82,7 @@ namespace Frankfurter.API.Client
             Endpoint.AppendPathSegment(Routes.LatestEndpoint);
 
             if (amount > decimal.Zero) Endpoint.SetQueryParam("amount", amount);
-            if (from != CurrencyCode.None) Endpoint.SetQueryParam("from", from.ToString());
+            if (from != CurrencyCode.NONE) Endpoint.SetQueryParam("from", from.ToString());
             if (to != null) Endpoint.SetQueryParam("to", to.ToParameter());
 
 
@@ -103,7 +103,7 @@ namespace Frankfurter.API.Client
             );
 
             if (amount > decimal.Zero) Endpoint.SetQueryParam("amount", amount);
-            if (from != CurrencyCode.None) Endpoint.SetQueryParam("from", from.ToString());
+            if (from != CurrencyCode.NONE) Endpoint.SetQueryParam("from", from.ToString());
             if (to != null) Endpoint.SetQueryParam("to", to.ToParameter());
 
             var response = await GetAsync<ExchangeBaseApiResponse>()

--- a/src/Frankfurter.API.Client/FrankfurterClient.cs
+++ b/src/Frankfurter.API.Client/FrankfurterClient.cs
@@ -25,9 +25,7 @@ namespace Frankfurter.API.Client
             var response = await GetAsync<JsonObject>()
                 .ConfigureAwait(false);
 
-            if (response == null) return null;
-
-            return response.ToCurrencyList();
+            return response?.ToCurrencyList();
         }
 
         public async Task<Exchange> CurrencyConvertAsync(decimal amount, CurrencyCode from, CurrencyCode to)
@@ -41,9 +39,7 @@ namespace Frankfurter.API.Client
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
 
-            if (response == null) return null;
-
-            return response.ToExchange();
+            return response?.ToExchange();
         }
 
         public async Task<Exchange> CurrencyConvertByDateAsync(DateTime referenceDate, decimal amount, CurrencyCode from)
@@ -57,9 +53,7 @@ namespace Frankfurter.API.Client
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
 
-            if (response.IsNull()) return null;
-
-            return response.ToExchange();
+            return response.IsNull() ? null : response.ToExchange();
         }
 
         public async Task<Exchange> CurrencyConvertByLastPublishedDateAsync(decimal amount, CurrencyCode from)
@@ -72,9 +66,7 @@ namespace Frankfurter.API.Client
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
 
-            if (response.IsNull()) return null;
-
-            return response.ToExchange();
+            return response.IsNull() ? null : response.ToExchange();
         }
 
         public async Task<Exchange> CurrencyConvertByLastPublishedDateAsync(decimal amount, CurrencyCode from, IEnumerable<CurrencyCode> to)
@@ -89,9 +81,7 @@ namespace Frankfurter.API.Client
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
 
-            if (response.IsNull()) return null;
-
-            return response.ToExchange();
+            return response.IsNull() ? null : response.ToExchange();
         }
 
         public async Task<IEnumerable<Exchange>> CurrencyConvertByDateIntervalAsync(decimal amount, CurrencyCode from, IEnumerable<CurrencyCode> to, DateTime startDate, DateTime? endDate = null)
@@ -109,9 +99,7 @@ namespace Frankfurter.API.Client
             var response = await GetAsync<ExchangeBaseApiResponse>()
                 .ConfigureAwait(false);
 
-            if (response.IsNull()) return null;
-
-            return response.ToExchangeList();
+            return response.IsNull() ? null : response.ToExchangeList();
         }
     }
 }

--- a/src/Frankfurter.API.Client/FrankfurterClient.cs
+++ b/src/Frankfurter.API.Client/FrankfurterClient.cs
@@ -18,7 +18,7 @@ namespace Frankfurter.API.Client
         public FrankfurterClient(FrankfurterClientConfiguration configuration) : base(configuration) { }
         public FrankfurterClient(IFrankfurterClientHttpClient restApiClient) : base(restApiClient) { }
 
-        public async Task<IEnumerable<Currency>> GetAllAvaliableCurrenciesAsync()
+        public async Task<IEnumerable<Currency>> GetAllAvailableCurrenciesAsync()
         {
             Endpoint.AppendPathSegment(Routes.CurrencyEndpoint);
 

--- a/src/Frankfurter.API.Client/FrankfurterClient.cs
+++ b/src/Frankfurter.API.Client/FrankfurterClient.cs
@@ -2,12 +2,12 @@
 using Frankfurter.API.Client.Domain;
 using Frankfurter.API.Client.DTO.Response;
 using Frankfurter.API.Client.Extensions;
-using Frankfurter.API.Client.Infraestructure;
 using Frankfurter.API.Client.Resources;
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Frankfurter.API.Client.Infrastructure;
 
 namespace Frankfurter.API.Client
 {

--- a/src/Frankfurter.API.Client/IFrankfurterClient.cs
+++ b/src/Frankfurter.API.Client/IFrankfurterClient.cs
@@ -7,7 +7,7 @@ namespace Frankfurter.API.Client
 {
     public interface IFrankfurterClient
     {
-        Task<IEnumerable<Currency>> GetAllAvaliableCurrenciesAsync();
+        Task<IEnumerable<Currency>> GetAllAvailableCurrenciesAsync();
         Task<Exchange> CurrencyConvertAsync(decimal amount, CurrencyCode from, CurrencyCode to);
         Task<Exchange> CurrencyConvertByDateAsync(DateTime referenceDate, decimal amount, CurrencyCode from);
         Task<Exchange> CurrencyConvertByLastPublishedDateAsync(decimal amount, CurrencyCode from);

--- a/src/Frankfurter.API.Client/Infrastructure/FrankfurterClientHttpClient.cs
+++ b/src/Frankfurter.API.Client/Infrastructure/FrankfurterClientHttpClient.cs
@@ -1,8 +1,8 @@
-﻿using Frankfurter.API.Client.Configuration;
+﻿using System.Threading.Tasks;
+using Frankfurter.API.Client.Configuration;
 using RestSharp;
-using System.Threading.Tasks;
 
-namespace Frankfurter.API.Client.Infraestructure
+namespace Frankfurter.API.Client.Infrastructure
 {
     public class FrankfurterClientHttpClient : IFrankfurterClientHttpClient
     {

--- a/src/Frankfurter.API.Client/Infrastructure/IFrankfurterClientHttpClient.cs
+++ b/src/Frankfurter.API.Client/Infrastructure/IFrankfurterClientHttpClient.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using RestSharp;
 
-namespace Frankfurter.API.Client.Infraestructure
+namespace Frankfurter.API.Client.Infrastructure
 {
     public interface IFrankfurterClientHttpClient
     {

--- a/test/Frankfurter.API.Client.IntegrationTest/FrankfurterClientTest.cs
+++ b/test/Frankfurter.API.Client.IntegrationTest/FrankfurterClientTest.cs
@@ -6,7 +6,7 @@ namespace Frankfurter.API.Client.IntegrationTest
     public class FrankfurterClientTest
     {
         private readonly IFrankfurterClient _client;
-        private const string _wrongBaseUrl = "http://localhost:4200";
+        private const string WrongBaseUrl = "http://localhost:4200";
 
         public FrankfurterClientTest()
         {
@@ -33,7 +33,7 @@ namespace Frankfurter.API.Client.IntegrationTest
         {
             var configuration = new FrankfurterClientConfiguration
             {
-                BaseApiUrl = _wrongBaseUrl,
+                BaseApiUrl = WrongBaseUrl,
                 MaxTimeout = 1,
                 ThrowOnAnyError = true
             };

--- a/test/Frankfurter.API.Client.IntegrationTest/FrankfurterClientTest.cs
+++ b/test/Frankfurter.API.Client.IntegrationTest/FrankfurterClientTest.cs
@@ -19,9 +19,9 @@ namespace Frankfurter.API.Client.IntegrationTest
         }
 
         [Fact]
-        public async void GetAllAvaliableCurrenciesAsync_Success()
+        public async void GetAllAvailableCurrenciesAsync_Success()
         {
-            var currencies = await _client.GetAllAvaliableCurrenciesAsync();
+            var currencies = await _client.GetAllAvailableCurrenciesAsync();
 
             Assert.NotNull(currencies);
             Assert.NotEmpty(currencies);
@@ -29,7 +29,7 @@ namespace Frankfurter.API.Client.IntegrationTest
         }
 
         [Fact]
-        public async void GetAllAvaliableCurrenciesAsync_Fail_Timeout()
+        public async void GetAllAvailableCurrenciesAsync_Fail_Timeout()
         {
             var configuration = new FrankfurterClientConfiguration
             {
@@ -40,7 +40,7 @@ namespace Frankfurter.API.Client.IntegrationTest
 
             var client = new FrankfurterClient(configuration);
 
-            Func<Task> act = () => client.GetAllAvaliableCurrenciesAsync();
+            Func<Task> act = () => client.GetAllAvailableCurrenciesAsync();
 
             await Assert.ThrowsAsync<TimeoutException>(act);
         }

--- a/test/Frankfurter.API.Client.UnitTest/FrankfurterClientTest.cs
+++ b/test/Frankfurter.API.Client.UnitTest/FrankfurterClientTest.cs
@@ -1,5 +1,4 @@
-﻿using Bogus.DataSets;
-using Frankfurter.API.Client.Domain;
+﻿using Frankfurter.API.Client.Domain;
 using Frankfurter.API.Client.DTO.Response;
 using Frankfurter.API.Client.Fixtures.Core;
 using Frankfurter.API.Client.Fixtures.DTO;

--- a/test/Frankfurter.API.Client.UnitTest/FrankfurterClientTest.cs
+++ b/test/Frankfurter.API.Client.UnitTest/FrankfurterClientTest.cs
@@ -3,9 +3,9 @@ using Frankfurter.API.Client.Domain;
 using Frankfurter.API.Client.DTO.Response;
 using Frankfurter.API.Client.Fixtures.Core;
 using Frankfurter.API.Client.Fixtures.DTO;
-using Frankfurter.API.Client.Infraestructure;
 using RestSharp;
 using System.Text.Json.Nodes;
+using Frankfurter.API.Client.Infrastructure;
 
 namespace Frankfurter.API.Client.UnitTest
 {

--- a/test/Frankfurter.API.Client.UnitTest/FrankfurterClientTest.cs
+++ b/test/Frankfurter.API.Client.UnitTest/FrankfurterClientTest.cs
@@ -21,13 +21,13 @@ namespace Frankfurter.API.Client.UnitTest
         }
 
         [Fact]
-        public async void GetAllAvaliableCurrenciesAsync_Success()
+        public async void GetAllAvailableCurrenciesAsync_Success()
         {
             _mockHttpClient.Setup(_ =>
                 _.GetAsync<JsonObject>(It.IsAny<RestRequest>()))
                 .ReturnsAsync(JsonObjectFixture.GenerateCurrenciesJsonObject());
 
-            var currencies = await _client.GetAllAvaliableCurrenciesAsync();
+            var currencies = await _client.GetAllAvailableCurrenciesAsync();
 
             Assert.NotNull(currencies);
             Assert.NotEmpty(currencies);
@@ -35,13 +35,13 @@ namespace Frankfurter.API.Client.UnitTest
         }
 
         [Fact]
-        public async void GetAllAvaliableCurrenciesAsync_Fail_NullResponse()
+        public async void GetAllAvailableCurrenciesAsync_Fail_NullResponse()
         {
             _mockHttpClient.Setup(_ =>
                 _.GetAsync<JsonObject>(It.IsAny<RestRequest>()))
                 .ReturnsAsync((JsonObject)null);
 
-            var currencies = await _client.GetAllAvaliableCurrenciesAsync();
+            var currencies = await _client.GetAllAvailableCurrenciesAsync();
 
             Assert.Null(currencies);
         }


### PR DESCRIPTION
- [X]  Change package to project reference on samples
- [X] Typo on the GetAllAvailableCurrenciesAsync  method name
- [X] Ignore new files and directories
- [X] Typo on the Infrastructure namespace
- [X] Rename None to NONE
- [X] Change for loop to LINQ expression
- [X] Remove unnecessary if and flag
- [X] Modify multiple if structure
- [X] Rename local constant WrongBaseUrl
- [X] Simplify null validation
- [X] Change ifs to return condition